### PR TITLE
압축 후 다운로드 된 파일을 열었을때 파일 목록이 표시되지 않던 오류 수정.

### DIFF
--- a/com.hangum.tadpole.commons.utils.zip/src/com/hangum/tadpole/commons/utils/zip/util/ZipUtils.java
+++ b/com.hangum.tadpole.commons.utils.zip/src/com/hangum/tadpole/commons/utils/zip/util/ZipUtils.java
@@ -45,7 +45,7 @@ public class ZipUtils {
 		String zipFullPath = PublicTadpoleDefine.TEMP_DIR + zipFile + ".zip";
 		ZipUtil.pack(new File(base_dir), new File(zipFullPath), new NameMapper() {
 			public String map(String name) {
-				return "/" + name;
+				return name;
 			}
 		});
 		


### PR DESCRIPTION
Windows7 기본 압출폴더에서 올챙이에서 압축 후 다운로드된 파일을 열었을때 파일 목록이 표시되지 않던 오류 수정.