### PR TITLE
쿼리결과 다운로드에서 한글(Unicode)파일명 오류 수정

### DIFF
--- a/com.hangum.tadpole.commons.utils.zip/src/com/hangum/tadpole/commons/utils/zip/util/ZipUtils.java
+++ b/com.hangum.tadpole.commons.utils.zip/src/com/hangum/tadpole/commons/utils/zip/util/ZipUtils.java
@@ -11,7 +11,10 @@
 package com.hangum.tadpole.commons.utils.zip.util;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 import org.zeroturnaround.zip.NameMapper;
 import org.zeroturnaround.zip.ZipUtil;
 
@@ -43,12 +46,22 @@ public class ZipUtils {
 	 */
 	public static String pack(String base_dir, String zipFile) throws Exception {
 		String zipFullPath = PublicTadpoleDefine.TEMP_DIR + zipFile + ".zip";
-		ZipUtil.pack(new File(base_dir), new File(zipFullPath), new NameMapper() {
-			public String map(String name) {
-				return name;
-			}
-		});
-		
-		return zipFullPath; 
+		ZipUtil.pack(new File(base_dir), new File(zipFullPath),
+				new NameMapper() {
+					public String map(String name) {
+						try {
+							if (!StringUtils.equals(name,StringEscapeUtils.escapeJava(name))) {
+								name = "download_files" + StringUtils.substring(name,StringUtils.lastIndexOf(name, '.'));
+							}
+							name = new String(name.getBytes(), "UTF-8");
+						} catch (UnsupportedEncodingException e) {
+							// TODO Auto-generated catch block
+							e.printStackTrace();
+						}
+						return name;
+					}
+				});
+
+		return zipFullPath;
 	}
 }

--- a/com.hangum.tadpole.commons/src/com/hangum/tadpole/commons/util/download/DownloadServiceHandler.java
+++ b/com.hangum.tadpole.commons/src/com/hangum/tadpole/commons/util/download/DownloadServiceHandler.java
@@ -11,6 +11,8 @@
 package com.hangum.tadpole.commons.util.download;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -65,6 +67,12 @@ public class DownloadServiceHandler implements ServiceHandler {
 	}
 
 	public void setName(String name) {
+		try {
+			name = URLEncoder.encode(name, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		this.name = name;
 	}
 


### PR DESCRIPTION
- 파일명이 한글일때 zip 파일명은 urlencoder를 사용해 한글파일명을 사용하고 압축되는 소스파일명은 영어로 변경해서
압축해서 다운로드하도록 한다.
- zipfile header :
https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html