### PR TITLE
22일 테스트 오류사항 수정.

### DIFF
--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/OracleSQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/OracleSQL.xml
@@ -576,19 +576,16 @@ select distinct
                             ,object_name
                             ,package_name
                             ,overload
-                            ,subprogram_id
                             ,CASE WHEN SUM (CASE WHEN argument_name IS NULL THEN 1 ELSE 0 END) > 0 THEN 'FUNCTION' ELSE 'PROCEDURE' END AS TYPE
                         FROM all_arguments
                     GROUP BY owner
                             ,object_name
                             ,package_name
-                            ,overload
-                            ,subprogram_id) p
+                            ,overload) p
                 ON 1=1
                AND p.owner = s.owner
                AND p.object_name = s.procedure_name
                AND p.package_name = s.object_name
-               AND p.subprogram_id = s.subprogram_id
  where 1=1
   and s.owner = (#schema_name#)
   and s.object_name = (#package_name#)

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/OracleSQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/OracleSQL.xml
@@ -80,22 +80,22 @@ ORDER BY T.table_name
      from sys.all_objects O
     where 1=1
 <isNotEmpty property="schema_name">
-	  and o.owner = (#schema_name#)
+	  and o.owner in (#schema_name#, upper(#schema_name#))
 </isNotEmpty>    
       and o.object_type not in ('SYNONYM')
-	  and object_name = #object_name#
+	  and object_name in (#object_name#, upper(#object_name#))
 	
 	UNION 	  
 	
 	select o.owner as object_owner, o.object_name as object_name, o.object_type as object_type
 	  from sys.all_objects o
 	       inner join sys.all_synonyms s
-	          on     s.synonym_name = (#object_name#)
+	          on     s.synonym_name in (#object_name#, upper(#object_name#))
 	             and o.owner = s.table_owner
 	             and o.object_name = s.table_name
 	 where     1 = 1
 <isNotEmpty property="schema_name">
-	  and o.owner = (#schema_name#)
+	  and o.owner in (#schema_name#, upper(#schema_name#))
 </isNotEmpty>    
       and o.object_type in ('TABLE', 'VIEW')
 </select>

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/TiberoSQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/TiberoSQL.xml
@@ -75,22 +75,22 @@
      from sys.all_objects O
     where 1=1
 <isNotEmpty property="schema_name">
-	  and o.owner = (#schema_name#)
+	  and o.owner in (#schema_name#, upper(#schema_name#))
 </isNotEmpty>    
       and o.object_type not in ('SYNONYM')
-	  and object_name = (#object_name#)
+	  and object_name in (#object_name#, upper(#object_name#))
 	
 	UNION 	  
 	
 	select o.owner as object_owner, o.object_name as object_name, o.object_type as object_type
 	  from sys.all_objects o
 	       inner join sys.all_synonyms s
-	          on     s.synonym_name = (#object_name#)
+	          on     s.synonym_name in (#object_name#, upper(#object_name#))
 	             and o.owner = s.org_object_owner
 	             and o.object_name = s.org_object_name
 	 where     1 = 1
 <isNotEmpty property="schema_name">
-	  and o.owner = (#schema_name#)
+	  and o.owner in (#schema_name#, upper(#schema_name#))
 </isNotEmpty>    
       and o.object_type in ('TABLE', 'VIEW')
 </select>

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/template/OracleDMLTemplate.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/template/OracleDMLTemplate.java
@@ -51,6 +51,9 @@ public class OracleDMLTemplate extends MySQLDMLTemplate {
 														  "RETURN CONCAT('Hello', param1);" + PublicTadpoleDefine.LINE_SEPARATOR + 
 														  "END; ";
 
+	/** sysnonym */
+	public static final String TMP_CREATE_SYNONYM_STMT = "CREATE SYNONYM {#schema#}.sn_sample FOR {#schema#}.sample_table;";
+
 	/** package */
 	public static final String  TMP_CREATE_PACKAGE_STMT = "CREATE OR REPLACE PACKAGE {#schema#}.PKG_SAMPLE " + PublicTadpoleDefine.LINE_SEPARATOR +
 														 " AS " + PublicTadpoleDefine.LINE_SEPARATOR +

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/actions/connections/CreateSynonymAction.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/actions/connections/CreateSynonymAction.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2013 hangum.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v2.1
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * 
+ * Contributors:
+ *     hangum - initial API and implementation
+ ******************************************************************************/
+package com.hangum.tadpole.rdb.core.actions.connections;
+
+import org.eclipse.jface.action.IAction;
+
+import com.hangum.tadpole.commons.libs.core.define.PublicTadpoleDefine;
+import com.hangum.tadpole.engine.query.dao.system.UserDBDAO;
+import com.hangum.tadpole.rdb.core.util.FindEditorAndWriteQueryUtil;
+import com.hangum.tadpole.rdb.core.util.QueryTemplateUtils;
+
+/**
+ * function 생성 action
+ * 
+ * @author hangum
+ *
+ */
+public class CreateSynonymAction extends AbstractQueryAction {
+
+	public CreateSynonymAction() {
+		super();
+	}
+
+	@Override
+	public void run(IAction action) {
+		UserDBDAO userDB = (UserDBDAO)sel.getFirstElement();
+		
+		FindEditorAndWriteQueryUtil.run(userDB, 
+					QueryTemplateUtils.getQuery(userDB, PublicTadpoleDefine.OBJECT_TYPE.SYNONYM), 
+					PublicTadpoleDefine.OBJECT_TYPE.SYNONYM);
+	}
+
+}

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/actions/object/rdb/object/ObjectCreatAction.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/actions/object/rdb/object/ObjectCreatAction.java
@@ -109,6 +109,9 @@ public class ObjectCreatAction extends AbstractObjectAction {
 		} else if(actionType == PublicTadpoleDefine.OBJECT_TYPE.FUNCTIONS) {
 			CreateFunctionAction cia = new CreateFunctionAction();
 			cia.run(userDB, actionType);
+		} else if(actionType == PublicTadpoleDefine.OBJECT_TYPE.SYNONYM) {
+			CreateFunctionAction cia = new CreateFunctionAction();
+			cia.run(userDB, actionType);
 		} else if(actionType == PublicTadpoleDefine.OBJECT_TYPE.TRIGGERS) {
 			CreateTriggerAction cia = new CreateTriggerAction();
 			cia.run(userDB, actionType);

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/actions/object/rdb/object/ObjectExplorerSelectionAction.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/actions/object/rdb/object/ObjectExplorerSelectionAction.java
@@ -49,7 +49,10 @@ public class ObjectExplorerSelectionAction extends AbstractObjectSelectAction {
 			Object obj = arryObj[arryObj.length-i-1];
 			
 			StructObjectDAO tcDAO = (StructObjectDAO)obj;
-			strColumnName += tcDAO.getSysName() + ", "; //$NON-NLS-1$
+			strColumnName += tcDAO.getFullName() + ", "; //$NON-NLS-1$
+			if (i > 1 && i % 5 == 0){
+				strColumnName += "\n";
+			}
 		}
 		strColumnName = StringUtils.removeEnd(strColumnName, ", "); //$NON-NLS-1$
 		

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/dml/GenerateStatmentDMLDialog.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/dml/GenerateStatmentDMLDialog.java
@@ -387,7 +387,11 @@ public class GenerateStatmentDMLDialog extends Dialog {
 							allDao.getSysName() + " as " + allDao.getColumnAlias(); //$NON-NLS-1$
 
 					sbColumn.append(strTableAlias);
+					if (chkComment.getSelection()) {
+						sbColumn.append("/* " + allDao.getType() +":"+ allDao.getComment()+ " */"); //$NON-NLS-1$ //$NON-NLS-2$
+					}
 				}
+				
 				cnt++;
 			}
 		}
@@ -398,7 +402,7 @@ public class GenerateStatmentDMLDialog extends Dialog {
 		resultSQL.append(" FROM " + SQLUtil.getTableName(userDB, tableDAO) + " " + this.textTableAlias.getText().trim()); //$NON-NLS-1$ //$NON-NLS-2$
 		cnt = 0;
 		for (ExtendTableColumnDAO allDao : (List<ExtendTableColumnDAO>) tableViewer.getInput()) {
-			if ("PK".equals(allDao.getKey())) { //$NON-NLS-1$
+			if ("PK".equals(allDao.getKey()) || "PRI".equals(allDao.getKey())) { //$NON-NLS-1$
 
 				if (cnt == 0) {
 					resultSQL.append(" WHERE "); //$NON-NLS-1$
@@ -442,7 +446,7 @@ public class GenerateStatmentDMLDialog extends Dialog {
 
 				resultSQL.append(allDao.getColumnNamebyTableAlias()).append(" = ? "); //$NON-NLS-1$
 				if (chkComment.getSelection()) {
-					resultSQL.append("/* " + allDao.getType() + " */"); //$NON-NLS-1$ //$NON-NLS-2$
+					resultSQL.append("/* " + allDao.getType() +":"+ allDao.getComment()+ " */"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 				cnt++;
 			}
@@ -458,7 +462,7 @@ public class GenerateStatmentDMLDialog extends Dialog {
 
 					resultSQL.append(allDao.getColumnNamebyTableAlias()).append(" = ? "); //$NON-NLS-1$
 					if (chkComment.getSelection()) {
-						resultSQL.append("/* " + allDao.getType() + " */"); //$NON-NLS-1$ //$NON-NLS-2$
+						resultSQL.append("/* " + allDao.getType() +":"+ allDao.getComment() + " */"); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 					cnt++;
 
@@ -508,6 +512,10 @@ public class GenerateStatmentDMLDialog extends Dialog {
 				if (cnt > 0)
 					resultSQL.append(", "); //$NON-NLS-1$
 				resultSQL.append(allDao.getSysName());
+				
+				if (chkComment.getSelection()){
+					resultSQL.append("/*" + allDao.getComment() + "*/");
+				}
 
 				cnt++;
 			}
@@ -519,6 +527,10 @@ public class GenerateStatmentDMLDialog extends Dialog {
 					if (cnt > 0)
 						resultSQL.append(", "); //$NON-NLS-1$
 					resultSQL.append(allDao.getSysName());
+					
+					if (chkComment.getSelection()) {
+						resultSQL.append("/* " + allDao.getComment() + " */"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					}
 
 					cnt++;
 				}

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/table/mysql/MySQLTaableCreateDialog.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/table/mysql/MySQLTaableCreateDialog.java
@@ -37,6 +37,7 @@ import com.hangum.tadpole.engine.query.dao.system.UserDBDAO;
 import com.hangum.tadpole.engine.sql.template.MySQLDMLTemplate;
 import com.hangum.tadpole.engine.sql.util.ExecuteDDLCommand;
 import com.hangum.tadpole.engine.sql.util.QueryUtils;
+import com.hangum.tadpole.engine.sql.util.SQLUtil;
 import com.hangum.tadpole.engine.sql.util.resultset.QueryExecuteResultDTO;
 import com.hangum.tadpole.engine.sql.util.resultset.TadpoleResultSet;
 import com.hangum.tadpole.rdb.core.Messages;
@@ -227,7 +228,7 @@ public class MySQLTaableCreateDialog extends TitleAreaDialog {
 		
 		if(MessageDialog.openConfirm(null, Messages.get().Confirm, Messages.get().TableCreationWantToCreate)) {
 			String strCreateTable = String.format(MySQLDMLTemplate.TMP_DIALOG_CREATE_TABLE,
-					tableCreateDao.getName(),
+					tableCreateDao.getFullName(userDB),
 					tableCreateDao.getEncoding(),
 					tableCreateDao.getCollation(),
 					tableCreateDao.getType());

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/table/mysql/TableCreateDAO.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/table/mysql/TableCreateDAO.java
@@ -10,6 +10,11 @@
  ******************************************************************************/
 package com.hangum.tadpole.rdb.core.dialog.table.mysql;
 
+import org.apache.commons.lang.StringUtils;
+
+import com.hangum.tadpole.engine.query.dao.system.UserDBDAO;
+import com.hangum.tadpole.engine.sql.util.SQLUtil;
+
 /**
  * table create dao
  * 
@@ -80,6 +85,14 @@ public class TableCreateDAO {
 	 */
 	public void setType(String type) {
 		this.type = type;
+	}
+
+	public String getFullName(UserDBDAO userDB) {
+		if(StringUtils.isBlank(userDB.getSchema())){
+			return SQLUtil.makeIdentifierName(userDB, this.getName());
+		}else{
+			return String.format("%s.%s", SQLUtil.makeIdentifierName(userDB, userDB.getSchema()), SQLUtil.makeIdentifierName(userDB, this.getName()) );
+		}
 	}
 	
 }

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/util/DialogUtil.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/util/DialogUtil.java
@@ -47,10 +47,10 @@ public class DialogUtil {
 		
 		SelectObjectDialog objectSelector = new SelectObjectDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), userDB, paramMap);
 
-		if (objectSelector.getSelectObject().isEmpty() | objectSelector.getObjectCount() > 1) {
+		if (objectSelector.getObjectCount() > 1) {
 			//이름으로 검색한 결과가 1개이상이면 선택화면을 띄운다.
 			objectSelector.open();
-		} else if (objectSelector.getObjectCount() <= 0) {
+		} else if (objectSelector.getObjectCount() <= 0 || objectSelector.getSelectObject().isEmpty()) {
 			//해당 오브젝트를 찾을 수 없습니다.
 			MessageDialog.openInformation(null , "Information" , "객체를 찾을 수 없습니다.");
 			return;
@@ -97,7 +97,7 @@ public class DialogUtil {
 				}
 			} else {
 				//TODO: F4상세정보 조회에서도 테이블필터에 의해서 조회가 제한된 테이블인 경우는 조회하지 못하게 해야 하는가?
-				// 스키마가 다른경우는 예외로?
+				// 스키마가 다른경우는 예외로? 
 				for (TableDAO tmpTableDAO : listTable) {
 					if (StringUtils.equalsIgnoreCase(paramTableDAO.getName(), tmpTableDAO.getName()) && StringUtils.equalsIgnoreCase(paramTableDAO.getSchema_name(), tmpTableDAO.getSchema_name())) {
 						tableDao = tmpTableDAO;

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/util/QueryTemplateUtils.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/util/QueryTemplateUtils.java
@@ -79,6 +79,8 @@ public class QueryTemplateUtils {
 				defaultStr =  OracleDMLTemplate.TMP_CREATE_PACKAGE_STMT;
 			} else if(initAction == PublicTadpoleDefine.OBJECT_TYPE.FUNCTIONS) {
 				defaultStr =  OracleDMLTemplate.TMP_CREATE_FUNCTION_STMT;
+			} else if(initAction == PublicTadpoleDefine.OBJECT_TYPE.SYNONYM) {
+				defaultStr =  OracleDMLTemplate.TMP_CREATE_SYNONYM_STMT;
 			} else if(initAction == PublicTadpoleDefine.OBJECT_TYPE.TRIGGERS) {
 				defaultStr =  OracleDMLTemplate.TMP_CREATE_TRIGGER_STMT;
 			}

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/rdb/sysnonym/TadpoleSynonymComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/rdb/sysnonym/TadpoleSynonymComposite.java
@@ -59,6 +59,7 @@ import com.hangum.tadpole.rdb.core.Activator;
 import com.hangum.tadpole.rdb.core.Messages;
 import com.hangum.tadpole.rdb.core.actions.object.AbstractObjectAction;
 import com.hangum.tadpole.rdb.core.actions.object.rdb.generate.GenerateViewDDLAction;
+import com.hangum.tadpole.rdb.core.actions.object.rdb.object.ObjectCreatAction;
 import com.hangum.tadpole.rdb.core.actions.object.rdb.object.ObjectDropAction;
 import com.hangum.tadpole.rdb.core.actions.object.rdb.object.ObjectExecuteProcedureAction;
 import com.hangum.tadpole.rdb.core.actions.object.rdb.object.ObjectRefreshAction;
@@ -97,6 +98,7 @@ public class TadpoleSynonymComposite extends AbstractObjectComposite {
 	private List<OracleSynonymColumnDAO> showSynonymColumns;
 	private SynonymColumnComparator synonymColumnComparator;
 
+	private ObjectCreatAction creatAction_Synonym;
 	private AbstractObjectAction dropAction_Synonym;
 	private AbstractObjectAction refreshAction_Synonym;
 	private GenerateViewDDLAction viewDDLAction;
@@ -270,6 +272,7 @@ public class TadpoleSynonymComposite extends AbstractObjectComposite {
 	private void createSynonymMenu() {
 		if(getUserDB() == null) return;
 		
+		creatAction_Synonym = new ObjectCreatAction(getSite().getWorkbenchWindow(), PublicTadpoleDefine.OBJECT_TYPE.SYNONYM, Messages.get().Synonym + " " + Messages.get().Created);
 		dropAction_Synonym = new ObjectDropAction(getSite().getWorkbenchWindow(), PublicTadpoleDefine.OBJECT_TYPE.SYNONYM, Messages.get().DropSynonym); //$NON-NLS-1$
 		refreshAction_Synonym = new ObjectRefreshAction(getSite().getWorkbenchWindow(), PublicTadpoleDefine.OBJECT_TYPE.SYNONYM, Messages.get().Refresh); //$NON-NLS-1$
 		executeAction = new ObjectExecuteProcedureAction(getSite().getWorkbenchWindow(), PublicTadpoleDefine.OBJECT_TYPE.SYNONYM, Messages.get().Execute); //$NON-NLS-1$
@@ -278,6 +281,7 @@ public class TadpoleSynonymComposite extends AbstractObjectComposite {
 		// menu
 		final MenuManager menuMgr = new MenuManager("#PopupMenu", "Synonym"); //$NON-NLS-1$ //$NON-NLS-2$
 		if(!isDDLLock()) {
+			menuMgr.add(creatAction_Synonym);
 			menuMgr.add(dropAction_Synonym);
 			menuMgr.add(new Separator());
 		}
@@ -394,6 +398,7 @@ public class TadpoleSynonymComposite extends AbstractObjectComposite {
 	public void initAction() {
 		if(getUserDB() == null) return; 
 		
+		creatAction_Synonym.setUserDB(getUserDB());
 		dropAction_Synonym.setUserDB(getUserDB());
 		refreshAction_Synonym.setUserDB(getUserDB());
 		executeAction.setUserDB(getUserDB());
@@ -431,6 +436,7 @@ public class TadpoleSynonymComposite extends AbstractObjectComposite {
 	@Override
 	public void dispose() {
 		super.dispose();	
+		if(creatAction_Synonym != null) creatAction_Synonym.dispose();
 		if(dropAction_Synonym != null) dropAction_Synonym.dispose();
 		if(refreshAction_Synonym != null) refreshAction_Synonym.dispose();
 		if(viewDDLAction != null) viewDDLAction.dispose();

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/rdb/table/TadpoleTableComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/rdb/table/TadpoleTableComposite.java
@@ -294,10 +294,12 @@ public class TadpoleTableComposite extends AbstractObjectComposite {
 			public String getText(Object element) {
 				TableDAO table = (TableDAO) element;
 				final DBDefine selectDB = getUserDB().getDBDefine();
-				if(selectDB == DBDefine.ORACLE_DEFAULT | 
-						selectDB == DBDefine.POSTGRE_DEFAULT |
-						selectDB == DBDefine.MSSQL_DEFAULT |
-						selectDB == DBDefine.TIBERO_DEFAULT) {
+				if(selectDB == DBDefine.ORACLE_DEFAULT || 
+						selectDB == DBDefine.POSTGRE_DEFAULT ||
+						selectDB == DBDefine.MSSQL_DEFAULT ||
+						selectDB == DBDefine.TIBERO_DEFAULT ||
+						selectDB == DBDefine.MYSQL_DEFAULT ||
+						selectDB == DBDefine.MARIADB_DEFAULT) {
 					
 					if("".equals(table.getSchema_name()) || null == table.getSchema_name()) return table.getName();
 					return table.getSchema_name() + "."+ table.getName();

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/utils/TableColumnObjectQuery.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/utils/TableColumnObjectQuery.java
@@ -109,7 +109,8 @@ public class TableColumnObjectQuery {
 				userDB.getDBDefine() == DBDefine.CUBRID_DEFAULT
 		) {
 			for(TableColumnDAO tableColumnDao: listTableColumnDao) {
-				resultDao = deleteColumn(userDB, tableColumnDao.getTableDao().getSysName(), tableColumnDao.getField());
+				//TODO: 테이블 컬럼명에 공백이나 특수문자가 있을경우 getSysName을 사용할 수 있도록 처리가 필요함.
+				resultDao = deleteColumn(userDB, tableColumnDao.getTableDao().getFullName(), SQLUtil.makeIdentifierName(userDB, tableColumnDao.getField()));
 			}
 			
 		} else {
@@ -143,8 +144,8 @@ public class TableColumnObjectQuery {
 		RequestResultDAO addColumnResultDAO = null;
 		
 		String strQuery = String.format("ALTER TABLE %s ADD COLUMN %s %s %s COMMENT %s ", 
-											tableDAO.getSysName(), 
-											metaDataDao.getColumnName(), 
+											tableDAO.getFullName(), 
+											SQLUtil.makeIdentifierName(userDB, metaDataDao.getColumnName()), 
 											metaDataDao.getDataType(), 
 											metaDataDao.isNotNull()?"NOT NULL":"NULL", 
 											SQLUtil.makeQuote(metaDataDao.getComment())
@@ -182,9 +183,9 @@ public class TableColumnObjectQuery {
 		RequestResultDAO addColumnResultDAO = null;
 		
 		String strQuery = String.format("ALTER TABLE %s CHANGE COLUMN %s %s %s %s COMMENT %s ", 
-											tableDAO.getSysName(), 
-											tableColumnDAO.getField(),
-											metaDataDao.getColumnName(), 
+											tableDAO.getFullName(), 
+											SQLUtil.makeIdentifierName(userDB, tableColumnDAO.getField()),
+											SQLUtil.makeIdentifierName(userDB, metaDataDao.getColumnName()), 
 											metaDataDao.getDataType(), 
 											metaDataDao.isNotNull()?"NOT NULL":"NULL", 
 											SQLUtil.makeQuote(metaDataDao.getComment())

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/utils/TadpoleObjectQuery.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/utils/TadpoleObjectQuery.java
@@ -102,7 +102,7 @@ public class TadpoleObjectQuery {
 				stmt.execute();
 
 			} else if (userDB.getDBDefine() == DBDefine.MYSQL_DEFAULT || userDB.getDBDefine() == DBDefine.MARIADB_DEFAULT) {
-				String strSQL = String.format("ALTER TABLE %s COMMENT %s", dao.getSysName(), SQLUtil.makeQuote(dao.getComment()));
+				String strSQL = String.format("ALTER TABLE %s COMMENT %s", dao.getFullName(), SQLUtil.makeQuote(dao.getComment()));
 				if(logger.isDebugEnabled()) logger.debug(strSQL);
 				stmt = javaConn.prepareStatement(strSQL);
 				stmt.execute();


### PR DESCRIPTION
테스트 오류 및 개선사항
1. OK : 테이블명 에디터로 복사할때 스키마명이 포함되지 않는다.   getFullName()으로 변경.
2. OK : DML빌더에서 컬럼 코멘트를 포함하여 스크립트 생서하도록 기능 확장.
3. 트리거 수정 및 생성등 변경시 ExplorerViewer의 트리거 탭을 새로고침 한다.
4. NEXT : 인덱스, 제약조건등 F4를 누르면 상제 정보를 표시할 오브젝트 종류를 확장한다.
5. 제약조건 팝업메뉴에서 메뉴이름이 영어로 표시됨.
6. 에디터에서 컨텐츠 어시스턴트에서 테이블목록이 제대로 표시되지 않는다.
7. 트리거, 프로시져등 컴파일 에디터에서 컴파일 후 에러 메시지 표시안됨.
8. NEXT : 테이블생성, 컬럼, 추가,변경,삭제 UI 개발.
9. OK : 시노님 생성메뉴 추가. create synonym 시노님명칭 for hr.emp;
10. 프로시져, 패키지, 펑션, 트리거 컴파일 메뉴는 해당 ddl 스크립트를 프로시져 컴파일 에디터로 복사하고 컴파일을 실행시켜 주도록 개선하자~ ( 메뉴를 별도로 추가해서 처리하는것도 좋아보임…)
11. 10g에서는 패키지 뷰어에서 subprogram_id 컬럼이 없어서오류 발생.
12. OK : 에디터에서 f4누를때.. 객체명이 소문자일경우에는 조회되지 않음.
13. 함수에 팝업메뉴의 명칭이 ‘함수’, ‘펑션’ 이 혼재되어 있음.
14. 에디터 하단의 행,열 정보가 실제 행,열과 틀리게 표시됨.
