### PR TITLE
컬럼 코멘트 변경시 발생하는 오류 수정.

### DIFF
--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/utils/TableColumnObjectQuery.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/utils/TableColumnObjectQuery.java
@@ -275,18 +275,20 @@ public class TableColumnObjectQuery {
 											SQLUtil.makeQuote(columnDAO.getComment()));
 			ExecuteDDLCommand.executSQL(userDB, reqReResultDAO, strQuery);
 			
-			if (RDBTypeToJavaTypeUtils.isNumberType(columnDAO.getType())) {
-				strQuery = String.format("ALTER TABLE %s ALTER %s SET DEFAULT %s", 
-					tableDAO.getFullName(), 
-					SQLUtil.makeIdentifierName(userDB, columnDAO.getField()),  						
-					columnDAO.getDefault());
-				ExecuteDDLCommand.executSQL(userDB, reqReResultDAO, strQuery);
-			}else{
-				strQuery = String.format("ALTER TABLE %s ALTER %s SET DEFAULT %s", 
-					tableDAO.getFullName(), 
-					SQLUtil.makeIdentifierName(userDB, columnDAO.getField()),  						
-					SQLUtil.makeQuote(columnDAO.getDefault()));
-				ExecuteDDLCommand.executSQL(userDB, reqReResultDAO, strQuery);
+			if (null != columnDAO.getDefault()){
+				if (RDBTypeToJavaTypeUtils.isNumberType(columnDAO.getType())) {
+					strQuery = String.format("ALTER TABLE %s ALTER %s SET DEFAULT %s", 
+						tableDAO.getFullName(), 
+						SQLUtil.makeIdentifierName(userDB, columnDAO.getField()),  						
+						columnDAO.getDefault());
+					ExecuteDDLCommand.executSQL(userDB, reqReResultDAO, strQuery);
+				}else{
+					strQuery = String.format("ALTER TABLE %s ALTER %s SET DEFAULT %s", 
+						tableDAO.getFullName(), 
+						SQLUtil.makeIdentifierName(userDB, columnDAO.getField()),  						
+						SQLUtil.makeQuote(columnDAO.getDefault()));
+					ExecuteDDLCommand.executSQL(userDB, reqReResultDAO, strQuery);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
NOT NULL제약조건이 걸린 테이블이 TableColumnDAO의 getDefault()에서 null 이 리턴되어 발생하는 오류 