### PR TITLE
7.25 일 오류사항 정리

### DIFF
--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/MySQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/MySQL.xml
@@ -41,8 +41,11 @@ select 1
 <select id="tableListOnlyName" resultClass="com.hangum.tadpole.engine.query.dao.mysql.TableDAO" parameterClass="java.lang.String">
 	SELECT TABLE_NAME name
 	FROM INFORMATION_SCHEMA.TABLES
-	WHERE TABLE_SCHEMA = #db# 
-		AND TABLE_TYPE = 'BASE TABLE'
+	WHERE 1=1
+<isNotEmpty property="schema">
+	  AND TABLE_SCHEMA = #db# 
+</isNotEmpty>	
+      AND TABLE_TYPE = 'BASE TABLE'
 	ORDER BY name
 </select>
 
@@ -145,8 +148,11 @@ WHERE 1=1
          collation_name as collation_name,
          table_schema as SCHEMA_NAME
 	FROM information_schema.columns
-	WHERE table_schema = #schema# AND 
-		table_name = #table#
+	WHERE 1=1
+<isNotEmpty property="schema">
+	  AND table_schema = #schema# 
+</isNotEmpty>	
+	  AND table_name = #table#
 </select>
 
 <!-- 
@@ -297,9 +303,10 @@ select
 <select id="triggerAllList" resultClass="com.hangum.tadpole.engine.query.dao.mysql.TriggerDAO" parameterClass="java.lang.String">
   SELECT
     *
-  FROM
-    INFORMATION_SCHEMA.TRIGGERS
+  FROM INFORMATION_SCHEMA.TRIGGERS
+  WHERE TRIGGER_SCHEMA = #schema_name#
 </select>
+
 <select id="triggerList" resultClass="com.hangum.tadpole.engine.query.dao.mysql.TriggerDAO" parameterClass="java.util.Map">
   SELECT
     trigger_name as name

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/OracleSQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/OracleSQL.xml
@@ -46,8 +46,6 @@
   SELECT 
       T.table_name AS "NAME"
     FROM user_tables T 
-      LEFT JOIN USER_TAB_COMMENTS S
-            ON S.TABLE_NAME = T.TABLE_NAME
 ORDER BY T.table_name
 </select>
 
@@ -655,8 +653,11 @@ SELECT
         ,s.created
         , (CASE WHEN t.status = 'ENABLED' AND s.status = 'VALID' THEN 'VALID' ELSE 'INVALID' END) AS status
         , s.owner as schema_name
-    FROM user_objects s INNER JOIN user_triggers t ON S.OBJECT_NAME = t.trigger_name
-   WHERE s.object_type = 'TRIGGER'
+    FROM all_objects s 
+    	INNER JOIN all_triggers t ON s.owner = t.owner and S.OBJECT_NAME = t.trigger_name
+   WHERE 1=1
+     AND s.owner = #db_name#
+     AND s.object_type = 'TRIGGER'
 ORDER BY t.table_name, s.object_name
 </select>
 

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/TiberoSQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/TiberoSQL.xml
@@ -41,8 +41,7 @@
   SELECT 
       T.table_name AS "NAME"
   FROM ALL_TABLES T  
-      LEFT JOIN USER_TAB_COMMENTS S ON S.TABLE_NAME = T.TABLE_NAME
-  WHERE T.OWNER = user
+  WHERE T.OWNER = NVL(#schema, user)
   ORDER BY T.table_name
 </select>
 
@@ -645,8 +644,11 @@ ORDER BY s.object_name
         ,s.created
         , (CASE WHEN t.status = 'ENABLED' AND s.status = 'VALID' THEN 'VALID' ELSE 'INVALID' END) AS status
         , s.owner as schema_name
-    FROM user_objects s INNER JOIN user_triggers t ON S.OBJECT_NAME = t.trigger_name
-   WHERE s.object_type = 'TRIGGER'
+    FROM all_objects s 
+    	INNER JOIN all_triggers t ON s.owner = t.owner and S.OBJECT_NAME = t.trigger_name
+   WHERE 1=1
+     AND s.owner = #db_name#
+     AND s.object_type = 'TRIGGER'
 ORDER BY t.table_name, s.object_name
 </select>
 

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/sqlscripts/scripts/MySqlDDLScript.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/sqlscripts/scripts/MySqlDDLScript.java
@@ -26,6 +26,7 @@ import com.hangum.tadpole.engine.query.dao.mysql.TableDAO;
 import com.hangum.tadpole.engine.query.dao.mysql.TriggerDAO;
 import com.hangum.tadpole.engine.query.dao.rdb.InOutParameterDAO;
 import com.hangum.tadpole.engine.query.dao.system.UserDBDAO;
+import com.hangum.tadpole.engine.sql.util.SQLUtil;
 import com.ibatis.sqlmap.client.SqlMapClient;
 
 /**
@@ -71,7 +72,13 @@ public class MySqlDDLScript extends AbstractRDBDDLScript {
 		String strSource = ""+srcList.get("Create View");
 		strSource = StringUtils.substringAfterLast(strSource, "VIEW");
 		
-		return "CREATE VIEW " + strSource.trim();
+		String schema_name = SQLUtil.makeIdentifierName(userDB, tableDao.getSchema_name());
+		
+		if ( strSource.indexOf(schema_name.trim(), 0) > 1 ){
+			return "CREATE VIEW " + strSource.trim();
+		}else{
+			return "CREATE VIEW " + schema_name +"."+ strSource.trim();
+		}
 	}
 
 	/* (non-Javadoc)

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/editors/main/utils/ExtMakeContentAssistUtil.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/editors/main/utils/ExtMakeContentAssistUtil.java
@@ -27,6 +27,7 @@ import com.hangum.tadpole.engine.manager.TadpoleSQLManager;
 import com.hangum.tadpole.engine.query.dao.mysql.TableColumnDAO;
 import com.hangum.tadpole.engine.query.dao.mysql.TableDAO;
 import com.hangum.tadpole.engine.query.dao.system.UserDBDAO;
+import com.hangum.tadpole.engine.sql.util.SQLUtil;
 import com.hangum.tadpole.rdb.core.viewers.object.sub.utils.TadpoleObjectQuery;
 import com.hangum.tadpole.tajo.core.connections.TajoConnectionManager;
 import com.ibatis.sqlmap.client.SqlMapClient;
@@ -249,6 +250,9 @@ public class ExtMakeContentAssistUtil extends MakeContentAssistUtil {
 		}
 		
 		try {
+			//SQLMap에 파라미터로 전달할때는 ", `, [ 등을 제거하고 사용한다.
+			strTableName = SQLUtil.removeIdentifierQuoteString(userDB, strTableName);
+			
 			TableDAO table = new TableDAO(strTableName, "");
 			table.setSysName(strTableName);
 			table.setSchema_name(strSchemaName);


### PR DESCRIPTION
1) 오라클 패키지 컴파일 시 아래와 같은 오류 나타남
=> 오라클은 패키지 선언부와 패키지 바디를 분리하여 컴파일 해야함.

2) Oracle 패키지 생성시 기본 스크립트가 두개 생성됨.(이게 맞는건지요?)
=> 선언부와 몸체로 나눠서 생성되는 것이 정상임.

3) Mysql 쿼리 수행후 쿼리결과 직접 수정 화면에서 데이터 수정시 
=> 스키마 정보를 명확히 확인하기 어려음. 

4) Mysql 테이블 관계 생성 화면 오류
=> 수정되었음.

5) MySQL 트리거 DDL 보기
=> 오브젝트명칭 자체에 점(.)이 있는경우 오류가 발생함.

6) MySQL 뷰 DDL 보기에서 스키마 명이 붙어 있지 않고 생성됨.
=> 수정되었음.

7) MySQL 프로시저 컴파일 메뉴가 없는데 바른건가요?
=> DDL보기 후에 다시 실행시키면 동일 프로시져를 삭제후 다시 생성할거냐고 물어보고 있으므로 이 방법을 사용하면 됨.

8) 에디터에서 f4 누를때 oracle 외 다른 디비에서는 객체를 찾을 수 없다는 메시지 나옴. 
=> 수정되었음.
=> 오라클, 티베로, 마이에스큐엘, 마리아디비의 경우는 전체 오브젝트에서 검색후 명칭이 같은건이 1개 이상일 경우 선택상자를
표시하고 그렇지 않은경우는 기존 방식대로 테이블목록에서 검색 후 정보를 표시함.

9) 에디터에서 ""로 감쌓인 쿼리의 Cmd + i 를 눌러서 실행하면 오류 (오라클 디비, MySQL 의 `문자는 정상 파싱됨)
=> QuotedString을 제거하고 검색할 수 있도록 수정되었음.
=> 에이더 관련 정적 리소스가 변겨되었을 경우 캐싱되지 않고 자동리프레쉬 되게 하는 방법을 고민해 봐야함. ex)
ace_editor.js?v=20160726 

10) Content assist 기능(Ctrl+Space)에서 위의(2)번 케이스 일 경우 목록에 컬럼이 열리지
않는다.(에러남.)
=>“, `, [ 등으로 감싼 오브젝트 명에서 해당 문자들을 제거하고 순수 오브젝트 명을 SQLMap으로 전달하도록 수정.