### PR TITLE
fix #1057

### DIFF
--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/MSSQLSQL.xml
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/query/MSSQLSQL.xml
@@ -137,7 +137,7 @@ FROM sysobjects a INNER JOIN syscolumns b ON (a.id = b.id)
 	AND p.class = 1
 	AND p.name = 'MS_Description'	
 WHERE 1 = 1
-	and a.id = object_id('$table$')
+	and a.id = object_id('$schema$.$table$')
 ORDER BY a.id, b.colid
 </select>
 
@@ -455,7 +455,7 @@ from sys.tables  as tbl
 <!-- 
 	Table DDL Script
  -->
-<select id="getTableScript" resultClass="java.util.HashMap" parameterClass="java.lang.String">
+<select id="getTableScript" resultClass="java.util.HashMap" parameterClass="java.util.Map">
 	select 
 		'[' + s.table_schema + '.' + t.name + ']' as TABLE_NAME
 	    , c.name as COLUMN_NAME
@@ -472,7 +472,7 @@ from sys.tables  as tbl
 	   inner join sys.types d on c.system_type_id = d.system_type_id
 	   left join sys.default_constraints v on v.parent_object_id = t.object_id and c.column_id = v.parent_column_id
 	 where 1=1
-	    and t.object_id = object_id('$table_name$')
+	    and t.object_id = object_id('$schema_name$.$table_name$')
 	order by c.column_id
 </select>
 
@@ -480,7 +480,7 @@ from sys.tables  as tbl
 	Table DDL Script => Primary key list
  -->
  
-<select id="getTableScript.pk" resultClass="java.util.HashMap" parameterClass="java.lang.String">
+<select id="getTableScript.pk" resultClass="java.util.HashMap" parameterClass="java.util.Map">
 	select p.name as CONSTRAINT_NAME
 	, tc.name as COLUMN_NAME 
 	, c.is_descending_key as DESCENDING
@@ -490,7 +490,7 @@ from sys.tables  as tbl
 	  inner join sys.index_columns c on t.object_id = c.object_id 
 	  inner join sys.all_columns tc on tc.object_id = t.object_id and c.column_id = tc.column_id
 	  where 1=1
-	  and t.object_id = object_id('$table_name$')
+	  and t.object_id = object_id('$schema_name$.$table_name$')
 	order by c.key_ordinal
 
 </select>
@@ -499,7 +499,7 @@ from sys.tables  as tbl
 	Table DDL Script => Table, Column Comment Script
  -->
  
-<select id="getTableScript.comments" resultClass="java.lang.String" parameterClass="java.lang.String">
+<select id="getTableScript.comments" resultClass="java.lang.String" parameterClass="java.util.Map">
 SELECT
 	'exec sp_addextendedproperty ''MS_Description'', ''' 
 		+ convert(varchar, p.value) 
@@ -512,7 +512,7 @@ SELECT
    WHERE 1=1
         AND p.minor_id = 0
         AND p.class = 1
-        AND tbl.object_id = object_id('$table_name$')
+        AND tbl.object_id = object_id('$schema_name$.$table_name$')
         AND p.value &gt; ''
   UNION ALL
 SELECT  
@@ -528,7 +528,7 @@ FROM sysobjects a INNER JOIN syscolumns b ON (a.id = b.id)
 	LEFT OUTER JOIN dbo.sysindexkeys d ON (b.id =d.id and b.colid = d.colid and indid =1)
 	LEFT JOIN sys.extended_properties AS p ON p.major_id = a.id AND p.minor_id = b.colid AND p.class = 1
 WHERE 1=1
-  AND a.id = object_id('$table_name$')
+  AND a.id = object_id('$schema_name$.$table_name$')
   AND p.value &gt; ''
   
 </select>

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/sqlscripts/scripts/MSSQL_8_LE_DDLScript.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/sqlscripts/scripts/MSSQL_8_LE_DDLScript.java
@@ -53,11 +53,15 @@ public class MSSQL_8_LE_DDLScript extends AbstractRDBDDLScript {
 	public String getTableScript(TableDAO tableDAO) throws Exception {
 		SqlMapClient client = TadpoleSQLManager.getInstance(userDB);
 		
-		List<HashMap> srcList = client.queryForList("getTableScript", tableDAO.getName());
+		HashMap<String, String> paramMap = new HashMap<String, String>();
+		paramMap.put("schema_name", tableDAO.getSchema_name() == null ? userDB.getSchema() : tableDAO.getSchema_name()); //$NON-NLS-1$
+		paramMap.put("table_name", tableDAO.getName());	
+		
+		List<HashMap> srcList = client.queryForList("getTableScript", paramMap);
 		
 		StringBuilder result = new StringBuilder("");
 //		result.append("/* DROP TABLE " + tableDAO.getName() + " CASCADE CONSTRAINT; */ \n\n");
-		result.append("CREATE TABLE " + tableDAO.getName() + "( \n");
+		result.append("CREATE TABLE " + tableDAO.getFullName() + "( \n");
 		for (int i=0; i<srcList.size(); i++){
 			HashMap<String, Object> source =  srcList.get(i);
 			
@@ -98,7 +102,7 @@ public class MSSQL_8_LE_DDLScript extends AbstractRDBDDLScript {
 		}
 
 		// primary key 
-		List<HashMap> srcPkList = client.queryForList("getTableScript.pk", tableDAO.getName());				
+		List<HashMap> srcPkList = client.queryForList("getTableScript.pk", paramMap);				
 		for (int i=0; i<srcPkList.size(); i++){
 			HashMap<String, Object> source =  srcPkList.get(i);
 			if(i==0){
@@ -126,7 +130,7 @@ public class MSSQL_8_LE_DDLScript extends AbstractRDBDDLScript {
 		result.append("); \n\n");
 		
 		// table, column comments
-		List<String> srcCommentList = client.queryForList("getTableScript.comments", tableDAO.getName());				
+		List<String> srcCommentList = client.queryForList("getTableScript.comments", paramMap);				
 		for (int i=0; i<srcCommentList.size(); i++){
 			result.append( srcCommentList.get(i)+"\n");
 		}

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/rdb/table/TadpoleTableComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/viewers/object/sub/rdb/table/TadpoleTableComposite.java
@@ -222,7 +222,8 @@ public class TadpoleTableComposite extends AbstractObjectComposite {
 					
 					Object objDAO = is.getFirstElement();
 					TableDAO tableDao = (TableDAO) objDAO;
-					if (selectTableName.equals(tableDao.getName())) return;
+					// SelectionChanged 이벤트는 어차피 테이블 선택이 변경되었을때 발생하니까 굳이 한번더 비교하지 않아도 되지 않을까요?
+					//if (selectTableName.equals(tableDao.getName())) return;
 					
 					// column이 리프레쉬 될때만 selectTableName 값이 갱신되서 인덱스, 제약조건, 트리거 리프레쉬 전에 현재 선택된 테이블명 설정해줌.
 					setSelectTableName(tableDao.getName());
@@ -309,7 +310,7 @@ public class TadpoleTableComposite extends AbstractObjectComposite {
 			@Override
 			public String getText(Object element) {
 				TableDAO table = (TableDAO) element;
-				return table.getName();
+				return table.getFullName();// .getName();
 			}
 		});
 		tvColName.setEditingSupport(new TableCommentEditorSupport(tableListViewer, userDB, 0));


### PR DESCRIPTION
MS SQL에서 하나의 데이터 베이스에 여러 스키마가 존재할 경우 각각의 스키마에 동일한 명칭의 테이블을 표시할때 혼란스럽지 않도록 스키마명 + 테이블명으로 표시하도록 수정.